### PR TITLE
Fix agent bus broadcast to enable multi-agent coordination

### DIFF
--- a/src/agents/core.py
+++ b/src/agents/core.py
@@ -6,17 +6,32 @@ from src.llm import LLMAdapter, LLMConfig, LLMProvider
 from src.stealth import StealthManager, StealthLevel
 
 class AgentBus:
+    """Simple pub/sub message bus for coordinating agents."""
+
     def __init__(self):
-        self.q = asyncio.Queue()
-        self.subscribers = set()
+        self.subscribers: set[asyncio.Queue] = set()
+
+    def subscribe(self) -> asyncio.Queue:
+        """Register a new subscriber and return its dedicated queue."""
+        queue: asyncio.Queue = asyncio.Queue()
+        self.subscribers.add(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue):
+        """Remove a subscriber queue from the bus."""
+        self.subscribers.discard(queue)
 
     async def publish(self, msg: Dict[str, Any]):
-        await self.q.put(msg)
+        """Broadcast a message to all subscribers."""
+        if not self.subscribers:
+            return
 
-    async def subscribe(self):
-        while True:
-            msg = await self.q.get()
-            yield msg
+        for queue in list(self.subscribers):
+            try:
+                await queue.put(msg)
+            except asyncio.QueueFull:
+                # Shouldn't happen with default asyncio.Queue, but guard just in case
+                continue
 
 @dataclass
 class AgentMemory:
@@ -71,16 +86,27 @@ class BaseAgent:
         self.memory = AgentMemory()
         self.running = False
         self.stealth_manager = stealth_manager
+        self.subscription_queue: Optional[asyncio.Queue] = None
 
     async def start(self):
         """Start the agent's main loop."""
         self.running = True
+        if not self.subscription_queue:
+            self.subscription_queue = self.bus.subscribe()
         # Don't await here - let the caller handle the task
         return asyncio.create_task(self.run())
 
     async def stop(self):
         """Stop the agent."""
         self.running = False
+        if self.subscription_queue:
+            # Wake up any pending consumers so the loop can exit cleanly
+            try:
+                self.subscription_queue.put_nowait({"_internal": "shutdown", "target": self.name})
+            except asyncio.QueueFull:
+                pass
+            self.bus.unsubscribe(self.subscription_queue)
+            self.subscription_queue = None
 
     async def run(self):
         """Main agent loop - to be implemented by subclasses."""
@@ -88,9 +114,14 @@ class BaseAgent:
 
     async def _iter_bus(self):
         """Iterate over bus messages."""
+        if not self.subscription_queue:
+            self.subscription_queue = self.bus.subscribe()
+
         while self.running:
             try:
-                msg = await asyncio.wait_for(self.bus.q.get(), timeout=1.0)
+                msg = await asyncio.wait_for(self.subscription_queue.get(), timeout=1.0)
+                if msg.get("_internal") == "shutdown" and msg.get("target") == self.name:
+                    continue
                 yield msg
             except asyncio.TimeoutError:
                 continue

--- a/src/flow.py
+++ b/src/flow.py
@@ -15,6 +15,7 @@ class FlowOrchestrator:
         self.running = True
         self.current_plan = None
         self.execution_queue = asyncio.Queue()
+        self.subscription_queue = self.bus.subscribe()
 
     async def run(self):
         """Main orchestrator loop."""
@@ -22,7 +23,9 @@ class FlowOrchestrator:
         
         while self.running:
             try:
-                msg = await asyncio.wait_for(self.bus.q.get(), timeout=1.0)
+                msg = await asyncio.wait_for(self.subscription_queue.get(), timeout=1.0)
+                if msg.get("_internal") == "shutdown" and msg.get("target") == "flow_orchestrator":
+                    continue
                 await self._handle_message(msg)
             except asyncio.TimeoutError:
                 continue
@@ -140,14 +143,18 @@ class FlowOrchestrator:
     async def _wait_for_approval(self, step_id: str, timeout: int = 600) -> bool:
         """Wait for approval of a step."""
         try:
+            approval_queue = self.bus.subscribe()
             while True:
-                msg = await asyncio.wait_for(self.bus.q.get(), timeout=timeout)
-                if (msg.get("type") == "approval" and 
+                msg = await asyncio.wait_for(approval_queue.get(), timeout=timeout)
+                if (msg.get("type") == "approval" and
                     msg.get("step_id") == step_id):
                     return msg.get("approved", False)
         except asyncio.TimeoutError:
             log.warning(f"Approval timeout for step {step_id}")
             return False
+        finally:
+            if 'approval_queue' in locals():
+                self.bus.unsubscribe(approval_queue)
 
     async def _handle_analysis(self, msg: Dict[str, Any]):
         """Handle analysis results from the analyzer agent."""
@@ -191,6 +198,13 @@ class FlowOrchestrator:
     async def stop(self):
         """Stop the orchestrator."""
         self.running = False
+        if self.subscription_queue:
+            try:
+                self.subscription_queue.put_nowait({"_internal": "shutdown", "target": "flow_orchestrator"})
+            except asyncio.QueueFull:
+                pass
+            self.bus.unsubscribe(self.subscription_queue)
+            self.subscription_queue = None
         log.info("Flow Orchestrator stopped")
 
 class AIFlowOrchestrator(FlowOrchestrator):


### PR DESCRIPTION
## Summary
- refactor `AgentBus` to support true pub/sub semantics so all agents receive shared messages
- update base agent loops and flow orchestrator to consume from dedicated subscription queues and shut down cleanly
- ensure approval waits use temporary subscriptions to avoid starving the orchestrator loop

## Testing
- PYTHONPATH=. pytest *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68e47a3fe53883279f86c82f94a5218a