### PR TITLE
Improve debug logging detail

### DIFF
--- a/src/flow.py
+++ b/src/flow.py
@@ -1,12 +1,21 @@
 # src/flow.py
 import asyncio
+import json
 import logging
 from typing import Dict, Any, Optional
 from src.agents.core import AgentBus, AgentManager
 from src.plugins.base import Plugin
-from src.stealth import StealthManager
 
 log = logging.getLogger("flow")
+
+
+def _format_debug(data: Any) -> str:
+    """Safely format objects for debug logging."""
+
+    try:
+        return json.dumps(data, indent=2, sort_keys=True)
+    except (TypeError, ValueError):
+        return str(data)
 
 class FlowOrchestrator:
     def __init__(self, bus: AgentBus, plugins: Optional[list] = None):
@@ -20,22 +29,33 @@ class FlowOrchestrator:
     async def run(self):
         """Main orchestrator loop."""
         log.info("Starting Flow Orchestrator")
-        
+
+        current_message: Optional[Dict[str, Any]] = None
+
         while self.running:
             try:
-                msg = await asyncio.wait_for(self.subscription_queue.get(), timeout=1.0)
-                if msg.get("_internal") == "shutdown" and msg.get("target") == "flow_orchestrator":
+                current_message = await asyncio.wait_for(self.subscription_queue.get(), timeout=1.0)
+                log.debug("Received bus message: %s", _format_debug(current_message))
+
+                if (
+                    current_message.get("_internal") == "shutdown"
+                    and current_message.get("target") == "flow_orchestrator"
+                ):
                     continue
-                await self._handle_message(msg)
+                await self._handle_message(current_message)
             except asyncio.TimeoutError:
                 continue
-            except Exception as e:
-                log.error(f"Error in orchestrator: {e}")
+            except Exception:
+                log.exception(
+                    "Error in orchestrator while handling message: %s",
+                    _format_debug(current_message) if current_message else "<no message>",
+                )
 
     async def _handle_message(self, msg: Dict[str, Any]):
         """Handle messages from the agent bus."""
         msg_type = msg.get("type")
-        
+        log.debug("Processing message type '%s'", msg_type)
+
         if msg_type == "plan":
             await self._handle_plan(msg)
         elif msg_type == "analysis":
@@ -51,10 +71,11 @@ class FlowOrchestrator:
         """Handle a new plan from the planner agent."""
         plan = msg.get("plan", {})
         self.current_plan = plan
-        
+
         log.info(f"Received plan: {plan.get('objective', 'Unknown objective')}")
         log.info(f"Plan has {len(plan.get('steps', []))} steps")
-        
+        log.debug("Plan payload: %s", _format_debug(plan))
+
         # Start executing the plan
         await self._execute_plan(plan)
 
@@ -65,9 +86,10 @@ class FlowOrchestrator:
         for step in steps:
             if not self.running:
                 break
-                
+
             log.info(f"Executing step: {step.get('description', 'Unknown step')}")
-            
+            log.debug("Step payload: %s", _format_debug(step))
+
             # Check if step requires approval
             if step.get("requires_approval", False):
                 await self._request_approval(step)
@@ -84,8 +106,13 @@ class FlowOrchestrator:
                     "step": step,
                     "result": result
                 })
+                log.debug(
+                    "Published execution result for step %s: %s",
+                    step.get("id"),
+                    _format_debug(result),
+                )
             except Exception as e:
-                log.error(f"Error executing step {step['id']}: {e}")
+                log.exception("Error executing step %s", step.get("id"))
                 await self.bus.publish({
                     "type": "execution_result",
                     "step": step,
@@ -97,22 +124,33 @@ class FlowOrchestrator:
         """Execute a single step using appropriate plugins."""
         action = step.get("action", "")
         metadata = step.get("metadata", {})
-        
+
         # Find appropriate plugin for the action
         plugin = self._find_plugin_for_action(action)
         if not plugin:
+            log.warning(
+                "No plugin found for action '%s'. Metadata: %s",
+                action,
+                _format_debug(metadata),
+            )
             return {"error": f"No plugin found for action: {action}"}
-        
+
         # Create proposed action for plugin
         proposed_action = {
             "id": step["id"],
             "description": step.get("description", ""),
             "metadata": metadata
         }
-        
+
         # Execute using plugin
+        log.debug(
+            "Executing plugin '%s' with action: %s",
+            plugin.name,
+            _format_debug(proposed_action),
+        )
+
         result = await plugin.execute(proposed_action)
-        log.debug(f"Plugin '{plugin.name}' execution result: {result}")
+        log.debug("Plugin '%s' execution result: %s", plugin.name, _format_debug(result))
         return result
 
     def _find_plugin_for_action(self, action: str) -> Optional[Plugin]:
@@ -135,6 +173,7 @@ class FlowOrchestrator:
     async def _request_approval(self, step: Dict[str, Any]):
         """Request approval for a high-risk step."""
         log.info(f"Requesting approval for step: {step.get('description')}")
+        log.debug("Approval request payload: %s", _format_debug(step))
         await self.bus.publish({
             "type": "request_approval",
             "step": step
@@ -146,6 +185,11 @@ class FlowOrchestrator:
             approval_queue = self.bus.subscribe()
             while True:
                 msg = await asyncio.wait_for(approval_queue.get(), timeout=timeout)
+                log.debug(
+                    "Received approval message for step %s: %s",
+                    step_id,
+                    _format_debug(msg),
+                )
                 if (msg.get("type") == "approval" and
                     msg.get("step_id") == step_id):
                     return msg.get("approved", False)
@@ -160,9 +204,10 @@ class FlowOrchestrator:
         """Handle analysis results from the analyzer agent."""
         analysis = msg.get("analysis", {})
         step_id = msg.get("step_id")
-        
+
         log.info(f"Analysis for step {step_id}: {analysis.get('threat_level', 'unknown')} threat level")
-        
+        log.debug("Analysis payload: %s", _format_debug(analysis))
+
         # Log findings and recommendations
         findings = analysis.get("findings", [])
         if findings:
@@ -176,12 +221,13 @@ class FlowOrchestrator:
         """Handle risk assessment from the executor agent."""
         assessment = msg.get("assessment", {})
         action_id = msg.get("action_id")
-        
+
         risk_level = assessment.get("risk_level", "unknown")
         recommendation = assessment.get("recommendation", "proceed")
-        
+
         log.info(f"Risk assessment for action {action_id}: {risk_level} risk, recommendation: {recommendation}")
-        
+        log.debug("Risk assessment payload: %s", _format_debug(assessment))
+
         if recommendation == "abort":
             log.warning(f"High-risk action {action_id} recommended for abortion")
 
@@ -189,15 +235,26 @@ class FlowOrchestrator:
         """Handle execution results."""
         step = msg.get("step", {})
         result = msg.get("result", {})
-        
+
+        log.debug(
+            "Execution result received for step %s: %s",
+            step.get("id"),
+            _format_debug(msg),
+        )
+
         if msg.get("error"):
-            log.error(f"Execution error in step {step.get('id')}: {result}")
+            log.error(
+                "Execution error in step %s: %s",
+                step.get("id"),
+                _format_debug(result),
+            )
         else:
             log.info(f"Step {step.get('id')} completed successfully")
 
     async def stop(self):
         """Stop the orchestrator."""
         self.running = False
+        log.debug("Stopping Flow Orchestrator and cleaning up subscriptions")
         if self.subscription_queue:
             try:
                 self.subscription_queue.put_nowait({"_internal": "shutdown", "target": "flow_orchestrator"})

--- a/src/main.py
+++ b/src/main.py
@@ -142,8 +142,8 @@ async def main():
         else:
             await app.start()
             
-    except Exception as e:
-        log.error(f"Application error: {e}")
+    except Exception:
+        log.exception("Application error")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1,10 +1,18 @@
 import asyncio
+import json
 import logging
 from typing import List, Dict, Any
 from src.plugins.base import Plugin
 
 log = logging.getLogger("orchestrator")
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def _format_debug(data: Any) -> str:
+    try:
+        return json.dumps(data, indent=2, sort_keys=True)
+    except (TypeError, ValueError):
+        return str(data)
 
 class Orchestrator:
     def __init__(self, plugins: List[Plugin]):
@@ -14,8 +22,11 @@ class Orchestrator:
     async def run_cycle(self):
         log.info("=== Starting orchestrator cycle ===")
         tasks = [p.propose_actions() for p in self.plugins]
+        log.debug("Gathering proposals from %d plugins", len(self.plugins))
+
         proposals = await asyncio.gather(*tasks)
         proposals = [item for sub in proposals for item in sub]  # flatten
+        log.debug("Collected proposals: %s", _format_debug(proposals))
 
         if not proposals:
             log.warning("No actions proposed by plugins.")
@@ -24,9 +35,14 @@ class Orchestrator:
         for action in proposals:
             plugin = self._find_plugin_for_action(action)
             log.info(f"[{plugin.name}] proposed: {action['description']}")
-            res = await plugin.execute(action)
+            log.debug("[%s] action payload: %s", plugin.name, _format_debug(action))
+            try:
+                res = await plugin.execute(action)
+            except Exception:
+                log.exception("[%s] Plugin execution failed", plugin.name)
+                continue
             log.info(f"[{plugin.name}] result: {res}")
-            log.debug(f"[{plugin.name}] detailed result: {res}")
+            log.debug(f"[{plugin.name}] detailed result: {_format_debug(res)}")
 
         log.info("=== Cycle complete ===")
 
@@ -34,6 +50,7 @@ class Orchestrator:
         for p in self.plugins:
             if p.name == action["metadata"].get("plugin"):
                 return p
+        log.error("Plugin not found for action: %s", _format_debug(action))
         raise RuntimeError("Plugin not found for action")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add structured debug logging across the flow orchestrator to expose message, plan, and plugin payloads when troubleshooting
- enhance the standalone orchestrator cycle with payload dumps and exception traces for proposal handling
- log full stack traces for unrecoverable errors in the main entry point

## Testing
- PYTHONPATH=. pytest -q *(fails: ModuleNotFoundError for src.plugins.example in upstream test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e70d1852148327974c9928a8d4fee8